### PR TITLE
slug amend

### DIFF
--- a/app/CustomFields/case-study-widgets.php
+++ b/app/CustomFields/case-study-widgets.php
@@ -13,6 +13,16 @@ add_action('agreable_app_theme_init', function() {
     'title' => 'Body',
     'fields' => array (
       array (
+        'key' => $key .'_preview_image',
+        'label' => 'Case Study Preview Image',
+        'name' => 'case_study_preview_image',
+        'type' => 'image',
+        'instructions' => 'This image will be shown on the main case study page as a preview to the case study. If it is left blank it will get the first image in the Basic Details image section.',
+        'required' => 1,
+        'return_format' => 'array',
+        'preview_size' => 'thumbnail',
+      ),
+      array (
         'key' => $key . '_widgets',
         'label' => 'Content Widgets',
         'name' => 'widgets',

--- a/app/custom-post-types.php
+++ b/app/custom-post-types.php
@@ -43,7 +43,7 @@
     'menu_position'       => 2,
     'menu_icon'           => 'dashicons-editor-ul',
     'can_export'          => true,
-    'has_archive'         => true,
+    'has_archive'         => false,
     'exclude_from_search' => false,
     'publicly_queryable'  => true,
     'capability_type' => 'post',

--- a/app/custom-post-types.php
+++ b/app/custom-post-types.php
@@ -21,6 +21,13 @@
     'not_found_in_trash'  => __( 'Not found in Trash', 'text_domain' ),
   );
 
+  $rewrite = [
+    'slug'                => 'case-study',
+    'with_front'          => true,
+    'pages'               => true,
+    'feeds'               => true,
+  ];
+
   $args = array(
     'label'               => __('case_studies', 'text_domain'),
     'description'         => __('Shortlist Media Case Studies', 'text_domain'),
@@ -36,12 +43,12 @@
     'menu_position'       => 2,
     'menu_icon'           => 'dashicons-editor-ul',
     'can_export'          => true,
-    'has_archive'         => false,
+    'has_archive'         => true,
     'exclude_from_search' => false,
     'publicly_queryable'  => true,
     'capability_type' => 'post',
     'map_meta_cap' => true,
-    'rewrite' => false,
+    'rewrite' => $rewrite,
     'query_var' => true,
   );
   \register_post_type('case_study', $args);


### PR DESCRIPTION
slug amend from casestudy to case-study.

Not just slug actually, there is also a new field in the CMS for a preview image for the main case study page.

Matt Phare wants to be able to make changes to these images and because the design is portrait and landscape image they can make the custom. If no image is set, is uses the first from the basic details header.
